### PR TITLE
Feature/remove utc timezone

### DIFF
--- a/AbeckDev.DbTimetable.Mcp/Services/TimeTableService.cs
+++ b/AbeckDev.DbTimetable.Mcp/Services/TimeTableService.cs
@@ -48,9 +48,32 @@ public class TimeTableService : ITimeTableService
         CancellationToken cancellationToken = default)
     {
         // Format: yyMMddHHmm (e.g., 2511051830 for 2025-11-05 18:30)
-        var germanTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
-        var dateParam = date?.ToString("yyMMdd") ?? germanTime.ToString("yyMMdd");
-        var hourParam = date?.ToString("HH") ?? germanTime.ToString("HH");
+        // If date is provided by user, use it directly (user is expected to provide German time)
+        // If not provided, get current time in German timezone
+        DateTime effectiveTime;
+        if (date.HasValue)
+        {
+            effectiveTime = date.Value;
+        }
+        else
+        {
+            try
+            {
+                var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+                effectiveTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                effectiveTime = DateTime.Now; // fallback to local time if timezone not found
+            }
+            catch (InvalidTimeZoneException)
+            {
+                effectiveTime = DateTime.Now; // fallback to local time if timezone invalid
+            }
+        }
+        
+        var dateParam = effectiveTime.ToString("yyMMdd");
+        var hourParam = effectiveTime.ToString("HH");
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"plan/{evaNo}/{dateParam}/{hourParam}");
         request.Headers.Add("DB-Client-Id", _config.ClientId);

--- a/AbeckDev.DbTimetable.Mcp/Services/TimeTableService.cs
+++ b/AbeckDev.DbTimetable.Mcp/Services/TimeTableService.cs
@@ -48,8 +48,9 @@ public class TimeTableService : ITimeTableService
         CancellationToken cancellationToken = default)
     {
         // Format: yyMMddHHmm (e.g., 2511051830 for 2025-11-05 18:30)
-        var dateParam = date?.ToString("yyMMdd") ?? DateTime.UtcNow.ToString("yyMMdd");
-        var hourParam = date?.ToString("HH") ?? DateTime.UtcNow.ToString("HH");
+        var germanTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time"));
+        var dateParam = date?.ToString("yyMMdd") ?? germanTime.ToString("yyMMdd");
+        var hourParam = date?.ToString("HH") ?? germanTime.ToString("HH");
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"plan/{evaNo}/{dateParam}/{hourParam}");
         request.Headers.Add("DB-Client-Id", _config.ClientId);

--- a/AbeckDev.DbTimetable.Mcp/Tools.cs
+++ b/AbeckDev.DbTimetable.Mcp/Tools.cs
@@ -46,7 +46,7 @@ public static class Tools
         [Description("Get station board (departures and arrivals) for a specific station in hourly slices. Returns XML data with train schedules.")]
         public async Task<string> GetStationBoard(
             [Description("EVA station number (e.g., 8000105 for Frankfurt Hauptbahnhof)")] string evaNo,
-            [Description("Date and time in format 'yyyy-MM-dd HH:mm' (UTC). Leave empty for current time.")] string? dateTime = null)
+            [Description("Date and time in format 'yyyy-MM-dd HH:mm' (German Time). Leave empty for current time.")] string? dateTime = null)
         {
             try
             {
@@ -119,7 +119,7 @@ public static class Tools
         public async Task<string> FindTrainConnections(
             [Description("Starting station name or EVA number (e.g., 'Frankfurt Hbf' or '8000105')")] string stationA,
             [Description("Destination station name or EVA number (e.g., 'Berlin Hbf' or '8011160')")] string stationB,
-            [Description("Date and time in format 'yyyy-MM-dd HH:mm' (UTC). Leave empty for current time.")] string? dateTime = null)
+            [Description("Date and time in format 'yyyy-MM-dd HH:mm' (German Time). Leave empty for current time.")] string? dateTime = null)
         {
             try
             {


### PR DESCRIPTION
This pull request updates the handling and documentation of date and time parameters for station board and train connection queries, ensuring time inputs and internal processing consistently use German local time instead of UTC. The main changes improve both user-facing documentation and backend logic to avoid confusion and potential errors related to time zones.

**Time zone handling improvements:**

* In `TimeTableService.cs`, the logic for determining the effective time now checks if a date is provided and uses it directly (assuming German time). If not provided, it converts the current UTC time to German local time (`Europe/Berlin`), with a fallback to local system time if the timezone is not found or invalid. (`[AbeckDev.DbTimetable.Mcp/Services/TimeTableService.csL51-R76](diffhunk://#diff-a95998e7d0d552b4b7817fc93dba4f27d029847f4b0eff4cadf1dc1876b17308L51-R76)`)

**Documentation updates:**

* In `Tools.cs`, the descriptions for the `dateTime` parameter in both `GetStationBoard` and `FindTrainConnections` methods have been updated to specify "German Time" instead of "UTC" to clarify expected input format for users. (`[[1]](diffhunk://#diff-ddb8e104d23f7d1eb044fc2272c33ada96451c3b77e2f7fbc8fe54bf1e10003aL49-R49)`, `[[2]](diffhunk://#diff-ddb8e104d23f7d1eb044fc2272c33ada96451c3b77e2f7fbc8fe54bf1e10003aL122-R122)`)